### PR TITLE
in function get_price_list specify engine as python

### DIFF
--- a/nsepy/history.py
+++ b/nsepy/history.py
@@ -308,7 +308,7 @@ def get_price_list(dt, segment='EQ'):
     res = price_list_url(yyyy, MMM, dt.strftime("%d%b%Y").upper() )
     txt =  unzip_str(res.content)
     fp = six.StringIO(txt)
-    df = pd.read_csv(fp)
+    df = pd.read_csv(fp, engine='python')
     del df['Unnamed: 13']
     return df
 


### PR DESCRIPTION
In some environments get_price_list function returns error `Error tokenizing data. C error: out of memory pandas python`
This is caused when pandas switches to "C" engine rather than Python engine. Explicitly putting engine='python' in pd.read_csv method fixes the issue.
More here https://pandas.pydata.org/pandas-docs/stable/generated/pandas.errors.ParserWarning.html